### PR TITLE
Use constant repository library path

### DIFF
--- a/salmonella.scm
+++ b/salmonella.scm
@@ -203,13 +203,10 @@
                             "csc"
                             (and mingw? "exe")))
         (tmp-repo-dir (make-pathname tmp-dir "repo"))
-        (binary-version
-         (shell-command-output csi '(-np "\"(##sys#fudge 42)\"")))
         (major-version
          (let ((v (shell-command-output csi '(-np "\"(chicken-version)\""))))
            (string->number (car (string-split v ".")))))
-        (lib-dir (make-pathname '("lib" "chicken") binary-version))
-        (tmp-repo-lib-dir (make-pathname tmp-repo-dir lib-dir))
+        (tmp-repo-lib-dir (make-pathname tmp-repo-dir "lib/chicken/0"))
         (tmp-repo-share-dir
          (make-pathname (list tmp-repo-dir "share") "chicken"))
         (egg-information (if eggs-source-dir


### PR DESCRIPTION
Rather than base the library path of the temporary repository on the active CHICKEN's binary version, use a constant path with a fake binary version ("0", so the resulting path is "lib/chicken/0"). This avoids the need to check a "fudge" value and keeps salmonella working on chicken-5.
