### PR TITLE
Update to work with 5.0.0pre4

### DIFF
--- a/salmonella-cmd.scm
+++ b/salmonella-cmd.scm
@@ -1,9 +1,13 @@
 (module salmonella-cmd ()
 
-(import chicken scheme)
-(import (chicken data-structures)
+(import scheme
+	(only chicken flush-output)
+	(chicken base)
+	(chicken data-structures)
         (chicken file)
+        (chicken fixnum)
         (chicken format)
+        (chicken process-context)
         (chicken random)
         (chicken string)
         (chicken time))

--- a/salmonella-common.scm
+++ b/salmonella-common.scm
@@ -1,8 +1,9 @@
-(import foreign)
-(import (chicken irregex)
+(import (chicken foreign)
+        (chicken irregex)
         (chicken pathname)
         (chicken port)
-        (chicken posix))
+        (chicken posix)
+        (chicken random))
 
 ;; Used to be chicken-prefix in C4
 (define default-installation-prefix (foreign-value "C_INSTALL_PREFIX" c-string))
@@ -100,7 +101,7 @@
     (let ((dir (make-pathname
                 (current-directory)
                 (string-append "salmonella-tmp-"
-                               (number->string (random 1000000) 16)))))
+                               (number->string (pseudo-random-integer 1000000) 16)))))
         (if (file-exists? dir)
             (loop)
             (begin

--- a/salmonella-log-parser.scm
+++ b/salmonella-log-parser.scm
@@ -35,11 +35,15 @@
  log-get
  )
 
-(import scheme chicken)
-(import (chicken data-structures)
+(import scheme
+	(only chicken flush-output)
+	(chicken base)
+	(chicken data-structures)
         (chicken io)
         (chicken file)
+        (chicken fixnum)
         (chicken format)
+        (chicken process-context)
         (chicken random)
         (chicken sort)
         (chicken string))
@@ -63,7 +67,7 @@
   (string? (car log)))
 
 (define (read-log-file log-file)
-  (let ((entries (with-input-from-file log-file read-all)))
+  (let ((entries (with-input-from-file log-file read-string)))
     ;; Ugly hack to avoid breaking on old log files. We don't actually
     ;; support parsing old logs at the moment -- just avoid crashing.
     (if (log-version-0? entries)

--- a/salmonella.scm
+++ b/salmonella.scm
@@ -12,12 +12,14 @@
  report-duration report-duration-set!
  )
 
-(import scheme chicken irregex foreign)
+(import scheme chicken)
 (import (chicken bitwise)
      (chicken data-structures)
      (chicken file)
+     (chicken foreign)
      (chicken format)
      (chicken io)
+     (chicken irregex)
      (chicken pathname)
      (chicken posix)
      (chicken port)
@@ -240,7 +242,7 @@
                 (unit-filenames
                  (handle-exceptions exn ;; FIXME: check cause of exception
                      #f
-                   (with-input-from-file import-libraries-file read-all))))
+                   (with-input-from-file import-libraries-file read-string))))
            (if unit-filenames
                (map (lambda (unit)
                       (string-chomp (symbol->string unit) ".import.so"))


### PR DESCRIPTION
Second attempt.

This just changes a few import short hands like foreign to (chicken foreign), and removes as much of the (import chicken) as possible, because that module will be eventually deleted.